### PR TITLE
[wait-for-gh-checks] Fix print_and_say method for multi-word content

### DIFF
--- a/bin/wait-for-gh-checks
+++ b/bin/wait-for-gh-checks
@@ -35,7 +35,7 @@ class WaitForChecksRunner
 
   def print_and_say(message)
     puts(message)
-    system("say #{message}")
+    system('say', message)
   end
 
   # rubocop:disable Metrics/CyclomaticComplexity


### PR DESCRIPTION
The Linux `spd-say` program only says the first argument, so if multi-word content was provided to `print_and_say`, it would only speak the first word. This makes the whole text content a single argument, so the whole content will be dictated.