### PR TITLE
[aliases] Add back hwm and wm aliases (which use wait-merge)

### DIFF
--- a/shell/aliases.zsh
+++ b/shell/aliases.zsh
@@ -1,4 +1,6 @@
 alias david="cd ~/code/david_runger"
+alias hwm='hpr && echo && wm'
+alias wm='wait-merge'
 
 if [ ! -v LINUX ]; then
   unalias ls > /dev/null 2>&1 || true


### PR DESCRIPTION
These were deleted, maybe overzealously, in c3ecaec1d34bae8f94125a971fa8d230252577fa .