### PR TITLE
[wait-merge] Use 'gdm' to delete merged branch

### DIFF
--- a/bin/wait-merge
+++ b/bin/wait-merge
@@ -3,7 +3,6 @@
 # wait for all expected GitHub checks to pass, then merge the PR
 
 set -euo pipefail # exit on any error, don't allow undefined variables, pass errors through pipes
-set -x
 
 GH_CHECKS_BRANCH=$(branch)
 export GH_CHECKS_BRANCH
@@ -19,8 +18,6 @@ else
   update-main-branches
 fi
 
-echo "--$GH_CHECKS_BRANCH=="
-git branch -d "$GH_CHECKS_BRANCH" # >/dev/null 2>&1
-prune-remote-branches-in-background
+gdm
 echo "----"
 git branch -vv


### PR DESCRIPTION
(This will also delete other branches that don't differ from the primary branch.)

Motivation: the `git branch -d` command was failing (silently, due to us suppressing the output) with a warning about the branch not being fully merged.

https://stackoverflow.com/questions/7548926/git-error-the-branch-x-is-not-fully-merged

One option would be to use `-D` rather than `-d` to force the deletion, but I guess that I feel more comfortable using `gdm` to only delete the branch if it really has been merged.

Since I think that this will fix the issue that was causing us not to reach the end of the script, I'm also removing the debugging changes that I had made to this file.