### PR TITLE
[z.rb/bmm] Add support for optional label argument

### DIFF
--- a/initializers/z.rb
+++ b/initializers/z.rb
@@ -435,7 +435,7 @@ def d
 end
 
 # [b]ench[m]ark [m]easure
-def bmm
+def bmm(label = nil)
   result = nil
   exception = nil
 
@@ -447,7 +447,7 @@ def bmm
     end
 
   puts(<<~LOG.squish)
-    #{AmazingPrint::Colors.cyan('BENCHMARK TIME:')}
+    #{AmazingPrint::Colors.cyan("#{label || 'BENCHMARK'} TIME:")}
     Took
     #{AmazingPrint::Colors.purple('%.3f' % time.round(3))}
     seconds.


### PR DESCRIPTION
This makes it easy to distinguish benchmark times from each other if using multiple benchmarks at the same times.