### PR TITLE
Remove redundant sidekiq logger customization

### DIFF
--- a/initializers/z.rb
+++ b/initializers/z.rb
@@ -303,42 +303,11 @@ if Rails.env.development? && $PROGRAM_NAME.include?('sidekiq')
     end
   end
 
-  module SidekiqExt; end
-
-  class SidekiqExt::JobLogger < Sidekiq::JobLogger
-    # This is basically copy-pasted from the Sidekiq source code, but we are adding
-    # `:queue` and `:args` to `Sidekiq::Context` so that they'll be logged.
-    def call(item, queue)
-      start = ::Process.clock_gettime(::Process::CLOCK_MONOTONIC)
-      Sidekiq::Context.add(:queue, queue)
-      json = JSON.dump(item['args'])
-      Sidekiq::Context.add(
-        :args,
-        AmazingPrint::Colors.cyan(json.size <= 140 ? json : "#{json[0...140]}...]"),
-      )
-      @logger.info('start')
-
-      yield
-
-      Sidekiq::Context.add(:elapsed, elapsed(start))
-      @logger.info('done')
-      # rubocop:disable Lint/RescueException
-      # This is what the Sidekiq source code does, so we'll do it here, too.
-    rescue Exception
-      # rubocop:enable Lint/RescueException
-      Sidekiq::Context.add(:elapsed, elapsed(start))
-      @logger.info('fail')
-
-      raise
-    end
-  end
-
   Sidekiq.configure_server do |config|
     if ENV['REDIS_DATABASE_NUMBER'] == '3'
       config.logger = nil
     else
       Sidekiq::Logger.prepend(RungerSidekiqLoggerPatches)
-      config[:job_logger] = SidekiqExt::JobLogger
     end
   end
 end


### PR DESCRIPTION
I have committed this (more or less, just without the cyan colorization of the args) to david_runger (github.com/davidrunger/david_runger/blob/24cf2b4d9c26a39b98186e9b8a6bf305d6e015d7/lib/sidekiq_ext/job_logger.rb), so no need to also do it here.